### PR TITLE
Fixing BigDecimal always mapped to Long

### DIFF
--- a/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/QueryStatement.java
+++ b/data-runtime/src/main/java/io/micronaut/data/runtime/mapper/QueryStatement.java
@@ -118,7 +118,7 @@ public interface QueryStatement<PS, IDX> {
                 }
             case BIGDECIMAL:
                 if (value instanceof BigDecimal) {
-                    setBigDecimal(statement, index, (BigDecimal) value);
+                    return setBigDecimal(statement, index, (BigDecimal) value);
                 } else if (value instanceof Number) {
                     return setBigDecimal(statement, index, new BigDecimal(((Number) value).doubleValue()));
                 } else {


### PR DESCRIPTION
When trying to save values of type BigDecimal we encountered loss of precision. We found out that if you try to save values of type BigDecimal micronaut-data will fall-through to the LONG block of the Switch Statement and convert any BigDecimal to Long values without any complaint. You just see you lost your decimal digits in the database.