### PR TITLE
Fix NullPointerException for Embedded null values

### DIFF
--- a/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/AbstractSqlRepositoryOperations.java
+++ b/data-jdbc/src/main/java/io/micronaut/data/jdbc/operations/AbstractSqlRepositoryOperations.java
@@ -147,7 +147,7 @@ public abstract class AbstractSqlRepositoryOperations<RS, PS> implements Reposit
                             if (assoc.getKind() == Relation.Kind.EMBEDDED) {
 
                                 Object value = prop.getProperty().get(entity);
-                                Object embeddedValue = embeddedProp.getProperty().get(value);
+                                Object embeddedValue = value != null ? embeddedProp.getProperty().get(value) : null;
                                 int index = i + 1;
                                 preparedStatementWriter.setDynamic(
                                         stmt,


### PR DESCRIPTION
If we have Embedded values in an entity and we have an instance of an entity where the embedded value is null, we get a NullPointerException.

i.e. we have a Class `Totals` which contains several subProperties of Type `@Embedded Monitary` (costs, turnover). Which each have the properties `currency` and `amount`.

Now if we have an instance where only `Monitary costs` is filled but `Monitary turnover` is null we get a NullpointerException at L150 because `value` in L149 is null.